### PR TITLE
Исправление обрезания Navigation Drawer сверху на новых версиях Android

### DIFF
--- a/app/src/main/java/com/dimonvideo/client/MainActivity.java
+++ b/app/src/main/java/com/dimonvideo/client/MainActivity.java
@@ -131,8 +131,8 @@ public class MainActivity extends AppCompatActivity {
 
         setContentView(binding.getRoot());
 
-        View root = binding.getRoot();
-        ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
+        View contentRoot = binding.appBarMain.getRoot();
+        ViewCompat.setOnApplyWindowInsetsListener(contentRoot, (v, insets) -> {
             Insets statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
             v.setPadding(0, statusBarInsets.top, 0, statusBarInsets.bottom);
             return insets;
@@ -189,6 +189,12 @@ public class MainActivity extends AppCompatActivity {
 
         DrawerLayout drawerLayout = binding.drawerLayout;
         navigationView = binding.navView;
+
+        ViewCompat.setOnApplyWindowInsetsListener(navigationView, (v, insets) -> {
+            Insets statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(v.getPaddingLeft(), statusBarInsets.top, v.getPaddingRight(), v.getPaddingBottom());
+            return insets;
+        });
 
         mAppBarConfiguration = new AppBarConfiguration.Builder(
                 R.id.nav_home, R.id.nav_new, R.id.nav_forum, R.id.nav_news,

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,7 +27,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:background="?attr/colorSurface"
-        android:fitsSystemWindows="true"
+        android:fitsSystemWindows="false"
         app:headerLayout="@layout/nav_header_main"
         app:itemIconTint="@color/year"
         app:itemTextColor="@color/text"


### PR DESCRIPTION
### Motivation
- На новых версиях Android боковое меню (`NavigationView`) могло отображаться с обрезанной верхней частью из-за некорректного или дублирующегося учета системных inset'ов, поэтому нужно корректно применять верхний отступ под статус-бар лишь к содержимому drawer.

### Description
- Перенес обработчик системных inset'ов с корня `DrawerLayout` на корневой контейнер основного контента `binding.appBarMain` через `ViewCompat.setOnApplyWindowInsetsListener` для корректного внутреннего отступа контента. 
- Добавил явную обработку `WindowInsets` для `navigationView`, чтобы установить верхний padding под статус-бар (`statusBarInsets.top`) и гарантировать корректное расположение header/пунктов меню. 
- Отключил автоматический учет системных окон у `NavigationView` в `activity_main.xml` (`android:fitsSystemWindows="false"`), чтобы избежать двойного или конфликтного применения inset'ов.

### Testing
- Проверил изменения через `git diff` и просмотр внесённых строк в `MainActivity.java` и `activity_main.xml`, разница соответствует ожидаемым правкам. 
- Закоммитил изменения (`git commit`) и создал PR, проверка статуса `git status` прошла успешно. 
- Полный набор автоматизированных тестов не запускался по явному запросу (тесты не запускать).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d509178e88832c8338231ff4212e3e)